### PR TITLE
fix replicate.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /cunet/evaluation/visualizing.py
 /vunet
 
+.replicate
+
 *.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/cunet/evaluation/results_replicate.py
+++ b/cunet/evaluation/results_replicate.py
@@ -11,5 +11,5 @@ def separate_audio_replicate(model, path_audio):
 
 
 def load_a_cunet():
-    model = load_model('/Users/meseguerbrocal/Desktop/tmp/models/with_val_all_files.h5')
+    model = load_model('with_val_all_files.h5')
     return model

--- a/replicate.yaml
+++ b/replicate.yaml
@@ -1,14 +1,20 @@
 version: "0.1"
 name: unet
 python: "3.6"
-workdir: cunet/evaluation
 python_requirements:
+  - sndfile
+  - pandas
+  - effortless-config
   - tensorflow==2.0.0a0
   - mir_eval==0.5
   - librosa==0.7.2
+system_packages:
+  - libsndfile-dev
 type:
   input: audio
-  output: timed_events
+  output:
+    type: audio
+    sample_rate: 44100
 run:
-  setup: results_replicate.py:load_a_cunet()
-  infer: results_replicate.py:separate_audio_replicate(model, path_audio)
+  setup: cunet/evaluation/results_replicate.py:load_a_cunet()
+  infer: cunet/evaluation/results_replicate.py:separate_audio_replicate(model, path_audio)


### PR DESCRIPTION
* `workdir` pointed to the evaluation directory, but the `results_replicate.py` file referenced modules from the root
* A couple missing dependencies
* External files (like weights etc) either have to be in a subdirectory of the replicated folder (though they don't have to be in git), or downloaded from the internet using the [`download`](https://beta-docs.replicate.ai/replicate-yaml#download)
* I added an `audio` output type (documented [here](https://beta-docs.replicate.ai/replicate-yaml#type))

`replicate check` now fails with this internal Keras error: ```WARN[0020]   File "/root/.pyenv/versions/3.6.10/lib/python3.6/site-packages/tensorflow/python/keras/engine/base_layer.py", line 2015, in __init__ 
WARN[0020]     self.node_def = node_def_pb2.NodeDef.FromString(node_def) 
WARN[0020] TypeError: a bytes-like object is required, not 'dict' ```